### PR TITLE
Rotate map with camera (if exists) instead of playerpawn

### DIFF
--- a/ZScript/ucm_minimap.zsc
+++ b/ZScript/ucm_minimap.zsc
@@ -208,6 +208,7 @@ class UCMinimap_EventHandler : EventHandler
 			mappos = plr.pos.xy;
 			size_mod = map_size/128.;
 			plr_rot = plr.angle;
+			if(players[consoleplayer].camera) plr_rot = players[consoleplayer].camera.angle;
 			baseoffs = ((25*size_mod)-useroffs.x, (25*size_mod)-useroffs.y);
 			curzoom = cv_radarzoom.GetFloat();
 		}
@@ -251,6 +252,10 @@ class UCMinimap_EventHandler : EventHandler
 		if(cv_mapfollow.GetBool())
 		{
 			plr_rot = Lerp(plr_rot, domaprotation ? plr.angle : 90, 0.5*deltatime);
+			if(players[consoleplayer].camera)
+			{
+				plr_rot = (domaprotation ? players[consoleplayer].camera.angle : 90); // Do not Lerp
+			}
 			mappos.x = Lerp(mappos.x, plr.pos.x, 0.5*deltatime);
 			mappos.y = Lerp(mappos.y, plr.pos.y, 0.5*deltatime);
 		}

--- a/ZScript/ucm_minimap.zsc
+++ b/ZScript/ucm_minimap.zsc
@@ -158,7 +158,7 @@ class UCMinimap_EventHandler : EventHandler
 	override void RenderOverlay(RenderEvent e)
 	{
 		let plr = players[consoleplayer].mo;
-		if(!plr) return;	
+		if(!plr || gamestate != GS_LEVEL) return;	
 		
 		// Deltatime
 		if(!prevMS)

--- a/ZScript/ucm_minimap.zsc
+++ b/ZScript/ucm_minimap.zsc
@@ -208,7 +208,7 @@ class UCMinimap_EventHandler : EventHandler
 			mappos = plr.pos.xy;
 			size_mod = map_size/128.;
 			plr_rot = plr.angle;
-			if(players[consoleplayer].camera) plr_rot = players[consoleplayer].camera.angle;
+			if(plr.player.camera) plr_rot = plr.player.camera.angle;
 			baseoffs = ((25*size_mod)-useroffs.x, (25*size_mod)-useroffs.y);
 			curzoom = cv_radarzoom.GetFloat();
 		}
@@ -252,9 +252,9 @@ class UCMinimap_EventHandler : EventHandler
 		if(cv_mapfollow.GetBool())
 		{
 			plr_rot = Lerp(plr_rot, domaprotation ? plr.angle : 90, 0.5*deltatime);
-			if(players[consoleplayer].camera)
+			if(plr.player.camera)
 			{
-				plr_rot = (domaprotation ? players[consoleplayer].camera.angle : 90); // Do not Lerp
+				plr_rot = (domaprotation ? plr.player.camera.angle : 90); // Do not Lerp
 			}
 			mappos.x = Lerp(mappos.x, plr.pos.x, 0.5*deltatime);
 			mappos.y = Lerp(mappos.y, plr.pos.y, 0.5*deltatime);


### PR DESCRIPTION
Using an external camera that can rotate its angle independent of the playerpawn is now taken care of.